### PR TITLE
Fix Docker setup

### DIFF
--- a/build/app/Dockerfile
+++ b/build/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.2-fpm
+FROM php:7.2-fpm as app
 
 RUN mkdir -p /usr/share/nginx/www/banner.wikipedia.de/current/var/cache \
     && mkdir -p /usr/share/nginx/www/banner.wikipedia.de/current/var/log \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,9 +27,5 @@ services:
     - PHP_FPM_HOST=app
     command: /bin/bash -c "envsubst '$$NGINX_HOST $$NGINX_PORT $$PHP_FPM_HOST' < /etc/nginx/conf.d/nginx.conf.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'"
 
-
 volumes:
   var-data:
-
-networks:
-  frontend-proxy:


### PR DESCRIPTION
Add target name to Dockerfile (used by docker-compose).
Remove network definition from docker-compose file. Network name was not
used by the services and at the moment there is no need to share the
network with other installations (e.g. FundraisingFrontend).