### PR TITLE
Fix issues with Symfony auto-wiring

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -18,7 +18,7 @@ services:
     # this creates a service per class whose id is the fully-qualified class name
     WMDE\BannerServer\:
         resource: '../src/*'
-        exclude: '../src/{DependencyInjection,Entity,Migrations,Tests,Kernel.php}'
+        exclude: '../src/{DependencyInjection,Migrations,Tests,Kernel.php}'
 
     # controllers are imported separately to make sure services can be injected
     # as action arguments even if you don't extend any base controller class

--- a/src/Entity/BannerSelection/CampaignCollection.php
+++ b/src/Entity/BannerSelection/CampaignCollection.php
@@ -14,7 +14,11 @@ class CampaignCollection {
 	 */
 	private $campaigns;
 
-	public function __construct( array $campaigns ) {
+	public function __construct( Campaign ...$campaigns ) {
 		$this->campaigns = $campaigns;
+	}
+
+	public function getCampaigns(): array {
+		return $this->campaigns;
 	}
 }


### PR DESCRIPTION
Symfony excludes directories named "Entity" from being auto-wired by
default because it assumes these are Doctrine entity classes. Since this
is not the case for the scope of this application, this exclusion is
removed.