### PR TITLE
Improve construction of BannerSelection

### DIFF
--- a/src/UseCase/BannerSelection/BannerSelection.php
+++ b/src/UseCase/BannerSelection/BannerSelection.php
@@ -13,7 +13,15 @@ class BannerSelection {
 	private $visitorData;
 	private $campaignEnd;
 
-	public function __construct( ?string $bannerIdentifier, Visitor $visitorData, \DateTime $campaignEnd ) {
+	public static function createBannerSelection( string $bannerIdentifier, Visitor $visitorData, \DateTime $campaignEnd ): self {
+		return new self( $bannerIdentifier, $visitorData, $campaignEnd );
+	}
+
+	public static function createEmptySelection( Visitor $visitor ): self {
+		return new self( null, $visitor, new \DateTime() );
+	}
+
+	private function __construct( ?string $bannerIdentifier, Visitor $visitorData, \DateTime $campaignEnd ) {
 		$this->bannerIdentifier = $bannerIdentifier;
 		$this->visitorData = $visitorData;
 		$this->campaignEnd = $campaignEnd;
@@ -23,7 +31,8 @@ class BannerSelection {
 		return $this->bannerIdentifier !== null;
 	}
 
-	public function getBannerIdentifier(): ?string {
+	public function getBannerIdentifier(): string {
+		assert( is_string( $this->bannerIdentifier ) );
 		return $this->bannerIdentifier;
 	}
 

--- a/src/UseCase/BannerSelection/BannerSelectionUseCase.php
+++ b/src/UseCase/BannerSelection/BannerSelectionUseCase.php
@@ -19,21 +19,14 @@ class BannerSelectionUseCase {
 
 	public function provideBannerRequest( Visitor $visitor ): BannerSelection {
 		if ( $visitor->hasDonated() ) {
-			return $this->cancelBannerSelection( $visitor );
+			return BannerSelection::createEmptySelection( $visitor );
 		}
 
-		return new BannerSelection(
+		return BannerSelection::createBannerSelection(
 			'test',
 			new Visitor( 1, 'Testbucket', false ),
 			new \DateTime()
 		);
 	}
 
-	private function cancelBannerSelection( Visitor $visitor ): BannerSelection {
-		return new BannerSelection(
-			null,
-			$visitor,
-			new \DateTime()
-		);
-	}
 }


### PR DESCRIPTION
To make the two different results of BannerSelectionUseCase more
explicit, use two different construction methods and make constructor
private.

Also, ensure that each "version" of the BannerSelection has the proper
value and matches its type definition.

A Follow-up for #14 