### PR TITLE
Use HTTP 200 response rather than HTTP 204

### DIFF
--- a/src/Controller/BannerSelectionController.php
+++ b/src/Controller/BannerSelectionController.php
@@ -31,7 +31,7 @@ class BannerSelectionController {
 	public function selectBanner( Request $request ): Response {
 		$bannerResponseData = $this->useCase->selectBanner( $this->buildValuesFromRequest( $request ) );
 		if ( !$bannerResponseData->displayBanner() ) {
-			$response = new Response( '', Response::HTTP_NO_CONTENT );
+			$response = new Response( '// Sorry, no banner for you!' );
 			$response->headers->set( 'Content-Type', 'application/javascript; charset=UTF-8' );
 			return $response;
 		}

--- a/tests/Unit/Controller/BannerSelectionControllerTest.php
+++ b/tests/Unit/Controller/BannerSelectionControllerTest.php
@@ -82,7 +82,7 @@ class BannerSelectionControllerTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( '/test_banners/TestBanner.js', $response->headers->get( 'location' ) );
 	}
 
-	public function test_given_impression_limit_is_reached_then_it_returns_no_content_response() {
+	public function test_given_impression_limit_is_reached_then_it_returns_http_ok_response() {
 		$testUseCase = new BannerSelectionUseCase(
 			CampaignFixture::getTrueRandomTestCampaignCollection(),
 			new ImpressionThreshold( VisitorFixture::VISITOR_TEST_IMPRESSION_COUNT ),
@@ -91,6 +91,7 @@ class BannerSelectionControllerTest extends \PHPUnit\Framework\TestCase {
 		$controller = new BannerSelectionController( $testUseCase, self::BANNER_PATH );
 		$response = $controller->selectBanner( VisitorFixture::getReturningVisitorRequest() );
 
-		$this->assertEquals( Response::HTTP_NO_CONTENT, $response->getStatusCode() );
+		$this->assertEquals( Response::HTTP_OK, $response->getStatusCode() );
+		$this->assertEquals( '// Sorry, no banner for you!', $response->getContent() );
 	}
 }


### PR DESCRIPTION
It looks like HTTP 204 is cached relatively aggressively by some
browsers and the content type is not set properly, so we should move to
using HTTP 200 and deliver some placeholder content.

https://phabricator.wikimedia.org/T224296