### PR TITLE
Add categories to campaigns and visitors

### DIFF
--- a/src/Controller/BannerSelectionController.php
+++ b/src/Controller/BannerSelectionController.php
@@ -18,7 +18,7 @@ class BannerSelectionController {
 
 	public const IMPRESSION_COUNT_COOKIE = 'impCount';
 	public const BUCKET_COOKIE = 'b';
-	public const DONATED_COOKIE = 'd';
+	public const CATEGORY_COOKIE = 'cat';
 
 	private $useCase;
 	private $bannerPath;
@@ -52,10 +52,12 @@ class BannerSelectionController {
 	}
 
 	private function buildValuesFromRequest( Request $request ): Visitor {
+		$rawCategories = $request->cookies->get( self::CATEGORY_COOKIE, '' );
+		$categories = array_filter( explode( ',', $rawCategories ) );
 		return new Visitor(
 			$request->cookies->getInt( self::IMPRESSION_COUNT_COOKIE, 0 ),
 			$request->cookies->get( self::BUCKET_COOKIE, null ),
-			$request->cookies->get( self::DONATED_COOKIE, false )
+			...$categories
 		);
 	}
 

--- a/src/Entity/BannerSelection/Campaign.php
+++ b/src/Entity/BannerSelection/Campaign.php
@@ -12,6 +12,7 @@ class Campaign {
 	private $identifier;
 	private $start;
 	private $end;
+	private $category;
 	private $rng;
 	private $displayPercentage;
 
@@ -25,6 +26,7 @@ class Campaign {
 		\DateTime $start,
 		\DateTime $end,
 		int $displayPercentage,
+		string $category,
 		RandomIntegerGenerator $rng,
 		Bucket $firstBucket,
 		Bucket ...$additionalBuckets ) {
@@ -32,6 +34,7 @@ class Campaign {
 		$this->identifier = $identifier;
 		$this->start = $start;
 		$this->end = $end;
+		$this->category = $category;
 		$this->displayPercentage = $displayPercentage;
 		$this->rng = $rng;
 		$this->buckets = array_merge( [$firstBucket], $additionalBuckets );
@@ -43,6 +46,10 @@ class Campaign {
 
 	public function getEnd(): \DateTime {
 		return $this->end;
+	}
+
+	public function getCategory(): string {
+		return $this->category;
 	}
 
 	public function isInActiveDateRange( \DateTime $time ): bool {

--- a/src/Entity/Visitor.php
+++ b/src/Entity/Visitor.php
@@ -11,12 +11,17 @@ class Visitor {
 
 	private $totalImpressionCount = 0;
 	private $bucketIdentifier;
-	private $hasDonated;
+	private $activeCategories;
 
-	public function __construct( int $totalImpressionCount, ?string $bucketIdentifier, bool $hasDonated ) {
+	/**
+	 * @param int $totalImpressionCount How many banners the visitor has seen overall
+	 * @param string|null $bucketIdentifier Last bucket identifier of the visitor (to put recurring visitors in the same buckets, but only per-campaign)
+	 * @param string ...$activeCategories Categories the user has interacted with (close button, donation, etc)
+	 */
+	public function __construct( int $totalImpressionCount, ?string $bucketIdentifier, string ...$activeCategories ) {
 		$this->totalImpressionCount = $totalImpressionCount;
 		$this->bucketIdentifier = $bucketIdentifier;
-		$this->hasDonated = $hasDonated;
+		$this->activeCategories = $activeCategories;
 	}
 
 	public function getTotalImpressionCount(): int {
@@ -27,7 +32,14 @@ class Visitor {
 		return $this->bucketIdentifier;
 	}
 
-	public function hasDonated(): bool {
-		return $this->hasDonated;
+	public function inCategory( string $categoryName ): bool {
+		return in_array( $categoryName, $this->activeCategories, true );
+	}
+
+	/**
+	 * @return string[]
+	 */
+	public function getCategories(): array {
+		return $this->activeCategories;
 	}
 }

--- a/src/UseCase/BannerSelection/BannerSelectionUseCase.php
+++ b/src/UseCase/BannerSelection/BannerSelectionUseCase.php
@@ -31,9 +31,9 @@ class BannerSelectionUseCase {
 	}
 
 	public function selectBanner( Visitor $visitor ): BannerSelectionData {
-		if ( $visitor->hasDonated() ||
-			$this->getCurrentCampaign() === null ||
+		if ( $this->getCurrentCampaign() === null ||
 			$this->impressionThreshold->isThresholdReached( $visitor->getTotalImpressionCount() ) ||
+			$visitor->inCategory( $this->getCurrentCampaign()->getCategory() ) ||
 			$this->isRatioLimited( $this->getCurrentCampaign()->getDisplayPercentage() ) ) {
 			return new EmptyBannerSelectionData( $visitor );
 		}
@@ -43,7 +43,11 @@ class BannerSelectionUseCase {
 		);
 
 		return new ActiveBannerSelectionData(
-			new Visitor( $visitor->getTotalImpressionCount() + 1, $visitorBucket->getIdentifier(), false ),
+			new Visitor(
+				$visitor->getTotalImpressionCount() + 1,
+				$visitorBucket->getIdentifier(),
+				...$visitor->getCategories()
+			),
 			$visitorBucket->getBanner( $visitor->getTotalImpressionCount() ),
 			$this->getCurrentCampaign()->getEnd()
 		);

--- a/src/Utils/CampaignConfigurationLoader.php
+++ b/src/Utils/CampaignConfigurationLoader.php
@@ -52,6 +52,7 @@ class CampaignConfigurationLoader {
 			new \DateTime( $campaignData['start'] ),
 			new \DateTime( $campaignData['end'] ),
 			(int)$campaignData['trafficLimit'],
+			$campaignData['category']?? 'default',
 			new SystemRandomIntegerGenerator(),
 			array_shift( $buckets ),
 			...$buckets

--- a/tests/Fixtures/CampaignFixture.php
+++ b/tests/Fixtures/CampaignFixture.php
@@ -10,6 +10,8 @@ use WMDE\BannerServer\Utils\SystemRandomIntegerGenerator;
 
 class CampaignFixture {
 
+	public const TEST_CATEGORY = 'test_category';
+
 	public static function getTestCampaignStartDate(): \DateTime {
 		return new \DateTime( '2000-01-01 00:00:00' );
 	}
@@ -24,7 +26,7 @@ class CampaignFixture {
 			self::getTestCampaignStartDate(),
 			self::getTestCampaignEndDate(),
 			$displayPercentage,
-			'default',
+			self::TEST_CATEGORY,
 			new SystemRandomIntegerGenerator(),
 			BucketFixture::getTestBucket()
 		);

--- a/tests/Fixtures/CampaignFixture.php
+++ b/tests/Fixtures/CampaignFixture.php
@@ -24,6 +24,7 @@ class CampaignFixture {
 			self::getTestCampaignStartDate(),
 			self::getTestCampaignEndDate(),
 			$displayPercentage,
+			'default',
 			new SystemRandomIntegerGenerator(),
 			BucketFixture::getTestBucket()
 		);

--- a/tests/Fixtures/VisitorFixture.php
+++ b/tests/Fixtures/VisitorFixture.php
@@ -12,7 +12,7 @@ class VisitorFixture {
 
 	public const VISITOR_TEST_IMPRESSION_COUNT = 5;
 	public const VISITOR_TEST_BUCKET = 'test_bucket';
-	public const VISITOR_TEST_DONATION_HISTORY = false;
+	public const VISITOR_TEST_DONATION_CATEGORY = 'fundraising_2020';
 
 	public static function getReturningVisitorRequest(): Request {
 		return new Request(
@@ -22,7 +22,7 @@ class VisitorFixture {
 			[
 				BannerSelectionController::IMPRESSION_COUNT_COOKIE => self::VISITOR_TEST_IMPRESSION_COUNT,
 				BannerSelectionController::BUCKET_COOKIE => self::VISITOR_TEST_BUCKET,
-				BannerSelectionController::DONATED_COOKIE => self::VISITOR_TEST_DONATION_HISTORY ]
+				BannerSelectionController::CATEGORY_COOKIE => self::VISITOR_TEST_DONATION_CATEGORY ]
 		);
 	}
 
@@ -30,15 +30,14 @@ class VisitorFixture {
 		return new Visitor(
 			self::VISITOR_TEST_IMPRESSION_COUNT,
 			self::VISITOR_TEST_BUCKET,
-			self::VISITOR_TEST_DONATION_HISTORY
+			self::VISITOR_TEST_DONATION_CATEGORY
 		);
 	}
 
 	public static function getFirstTimeVisitor(): Visitor {
 		return new Visitor(
 			0,
-			null,
-			false
+			null
 		);
 	}
 }

--- a/tests/Fixtures/campaigns/campaigns.yml
+++ b/tests/Fixtures/campaigns/campaigns.yml
@@ -17,3 +17,17 @@ B18WPDE_01_180131:
       banners:
         - B18WPDE_01_180131_fulltop_var
         - B18WPDE_01_180131_top_var
+
+B20WPDE_01_201111:
+  description: This is a simple campaign with a category
+  start: "2020-11-11 11:11:11"
+  end: "2020-11-25 14:00:00"
+  trafficLimit: 10
+  category: fundraising_2020
+  buckets:
+    - name: B20WPDE_01_201111_ctrl
+      banners:
+        - B20WPDE_01_201111_ctrl
+    - name: B20WPDE_01_201111_var
+      banners:
+        - B20WPDE_01_201111_var

--- a/tests/Unit/Entity/BannerSelection/CampaignCollectionTest.php
+++ b/tests/Unit/Entity/BannerSelection/CampaignCollectionTest.php
@@ -30,6 +30,7 @@ class CampaignCollectionTest extends TestCase {
 				new \DateTime( '2099-10-01 14:00:00' ),
 				new \DateTime( '2099-10-31 14:00:00' ),
 				1,
+				'default',
 				new FakeRandomIntegerGenerator( 1 ),
 				$this->getTestbucket()
 			),
@@ -38,6 +39,7 @@ class CampaignCollectionTest extends TestCase {
 				new \DateTime( '2018-10-01 14:00:00' ),
 				new \DateTime( '2018-10-31 14:00:00' ),
 				1,
+				'default',
 				new FakeRandomIntegerGenerator( 1 ),
 				$this->getTestbucket()
 			),
@@ -46,6 +48,7 @@ class CampaignCollectionTest extends TestCase {
 				new \DateTime( '1999-10-01 14:00:00' ),
 				new \DateTime( '1999-10-31 14:00:00' ),
 				1,
+				'default',
 				new FakeRandomIntegerGenerator( 1 ),
 				$this->getTestbucket()
 			)
@@ -63,6 +66,7 @@ class CampaignCollectionTest extends TestCase {
 				new \DateTime( '2018-10-01 14:00:00' ),
 				new \DateTime( '2018-10-31 14:00:00' ),
 				1,
+				'default',
 				new FakeRandomIntegerGenerator( 1 ),
 				$this->getTestbucket()
 			),
@@ -71,6 +75,7 @@ class CampaignCollectionTest extends TestCase {
 				new \DateTime( '1999-10-01 14:00:00' ),
 				new \DateTime( '1999-10-31 14:00:00' ),
 				1,
+				'default',
 				new FakeRandomIntegerGenerator( 1 ),
 				$this->getTestbucket()
 			)

--- a/tests/Unit/Entity/BannerSelection/CampaignTest.php
+++ b/tests/Unit/Entity/BannerSelection/CampaignTest.php
@@ -37,6 +37,7 @@ class CampaignTest extends TestCase {
 			new \DateTime( '2018-10-01 14:00:00' ),
 			new \DateTime( '2018-10-31 14:00:00' ),
 			1,
+			'default',
 			new FakeRandomIntegerGenerator( 1 ),
 			$this->getControlBucket(),
 			$this->getVariantBucket()
@@ -62,6 +63,7 @@ class CampaignTest extends TestCase {
 			new \DateTime( '2018-10-01 14:00:00' ),
 			new \DateTime( '2018-10-31 14:00:00' ),
 			1,
+			'default',
 			new FakeRandomIntegerGenerator( 1 ),
 			$this->getControlBucket(),
 			$this->getVariantBucket()
@@ -86,6 +88,7 @@ class CampaignTest extends TestCase {
 			new \DateTime( '2018-10-01 14:00:00' ),
 			new \DateTime( '2018-10-31 14:00:00' ),
 			1,
+			'default',
 			new FakeRandomIntegerGenerator( 1 ),
 			$this->getControlBucket(),
 			$this->getVariantBucket()
@@ -102,6 +105,7 @@ class CampaignTest extends TestCase {
 			new \DateTime( '2018-10-01 14:00:00' ),
 			new \DateTime( '2018-10-31 14:00:00' ),
 			1,
+			'default',
 			new FakeRandomIntegerGenerator( 1 ),
 			$this->getControlBucket(),
 			$this->getVariantBucket()
@@ -118,6 +122,7 @@ class CampaignTest extends TestCase {
 			new \DateTime( '2018-10-01 14:00:00' ),
 			new \DateTime( '2018-10-31 14:00:00' ),
 			1,
+			'default',
 			new FakeRandomIntegerGenerator( 1 ),
 			$this->getControlBucket(),
 			$this->getVariantBucket()
@@ -137,6 +142,7 @@ class CampaignTest extends TestCase {
 			new \DateTime( '2018-10-01 14:00:00' ),
 			$endDate,
 			$displayPercentage,
+			'default',
 			new FakeRandomIntegerGenerator( 1 ),
 			$this->getControlBucket(),
 			$this->getVariantBucket()

--- a/tests/Unit/Entity/VisitorTest.php
+++ b/tests/Unit/Entity/VisitorTest.php
@@ -15,17 +15,17 @@ class VisitorTest extends TestCase {
 	const TEST_IMPRESSION_COUNT = 2;
 	const TEST_BUCKET = 'TEST_BUCKET123';
 
-	public function test_given_visitor_who_has_donated_then_correct_values_are_returned(): void {
-		$visitor = new Visitor( self::TEST_IMPRESSION_COUNT, self::TEST_BUCKET, true );
+	public function test_given_visitor_without_categories_then_correct_values_are_returned(): void {
+		$visitor = new Visitor( self::TEST_IMPRESSION_COUNT, self::TEST_BUCKET );
 		$this->assertEquals( self::TEST_IMPRESSION_COUNT, $visitor->getTotalImpressionCount() );
 		$this->assertEquals( self::TEST_BUCKET, $visitor->getBucketIdentifier() );
-		$this->assertTrue( $visitor->hasDonated() );
+		$this->assertFalse( $visitor->inCategory( 'default' ) );
 	}
 
-	public function test_given_visitor_who_has_not_donated_then_correct_values_are_returned(): void {
-		$visitor = new Visitor( self::TEST_IMPRESSION_COUNT, self::TEST_BUCKET, false );
-		$this->assertEquals( self::TEST_IMPRESSION_COUNT, $visitor->getTotalImpressionCount() );
-		$this->assertEquals( self::TEST_BUCKET, $visitor->getBucketIdentifier() );
-		$this->assertFalse( $visitor->hasDonated() );
+	public function test_given_visitor_with_categories_then_correct_values_are_returned(): void {
+		$visitor = new Visitor( self::TEST_IMPRESSION_COUNT, self::TEST_BUCKET, 'default', 'fundraising_2020' );
+		$this->assertTrue( $visitor->inCategory( 'default' ) );
+		$this->assertTrue( $visitor->inCategory( 'fundraising_2020' ) );
+		$this->assertFalse( $visitor->inCategory( 'dummy_category' ) );
 	}
 }

--- a/tests/Unit/Utils/CampaignConfigurationLoaderTest.php
+++ b/tests/Unit/Utils/CampaignConfigurationLoaderTest.php
@@ -4,13 +4,14 @@ declare( strict_types = 1 );
 
 namespace WMDE\BannerServer\Tests\Unit\Utils;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Yaml\Exception\ParseException;
 use WMDE\BannerServer\Utils\CampaignConfigurationLoader;
 
 /**
  * @covers \WMDE\BannerServer\Utils\CampaignConfigurationLoader
  */
-class CampaignConfigurationLoaderTest extends \PHPUnit\Framework\TestCase {
+class CampaignConfigurationLoaderTest extends TestCase {
 
 	const TEST_VALID_CAMPAIGN_CONFIGURATION_FILE = 'tests/Fixtures/campaigns/campaigns.yml';
 	const TEST_BROKEN_BUCKET_CAMPAIGN_CONFIGURATION_FILE = 'tests/Fixtures/campaigns/broken_bucket_campaign.yml';
@@ -22,10 +23,13 @@ class CampaignConfigurationLoaderTest extends \PHPUnit\Framework\TestCase {
 		$collection = $loader->getCampaignCollection();
 
 		$campaign = $collection->getCampaign( new \DateTime( '2018-12-12' ) );
+		$categorizedCampaign = $collection->getCampaign( new \DateTime( '2020-11-12' ) );
 		$this->assertNotNull( $campaign );
 		$this->assertEquals( 'B18WPDE_01_180131', $campaign->getIdentifier() );
 		$this->assertEquals( '2019-01-01 14:00:00', $campaign->getEnd()->format( 'Y-m-d H:i:s' ) );
 		$this->assertEquals( 10, $campaign->getDisplayPercentage() );
+		$this->assertEquals( 'default', $campaign->getCategory() );
+		$this->assertEquals( 'fundraising_2020', $categorizedCampaign->getCategory() );
 
 		$bucketA = $campaign->selectBucket( 'B18WPDE_01_180131_ctrl' );
 		$bucketB = $campaign->selectBucket( 'B18WPDE_01_180131_var' );


### PR DESCRIPTION
Add categories to campaigns and visitors to check if visitors have interacted with banners and suppress banner display when visitor has an interaction cookie.

This is for https://phabricator.wikimedia.org/T243757