### PR TITLE
Handle client viewport width for campaigns

### DIFF
--- a/src/Controller/BannerSelectionController.php
+++ b/src/Controller/BannerSelectionController.php
@@ -57,7 +57,7 @@ class BannerSelectionController {
 		return new Visitor(
 			$request->cookies->getInt( self::IMPRESSION_COUNT_COOKIE, 0 ),
 			$request->cookies->get( self::BUCKET_COOKIE, null ),
-			$request->query->getInt('vWidth'),
+			$request->query->getInt( 'vWidth' ),
 			...$categories
 		);
 	}

--- a/src/Controller/BannerSelectionController.php
+++ b/src/Controller/BannerSelectionController.php
@@ -57,6 +57,7 @@ class BannerSelectionController {
 		return new Visitor(
 			$request->cookies->getInt( self::IMPRESSION_COUNT_COOKIE, 0 ),
 			$request->cookies->get( self::BUCKET_COOKIE, null ),
+			$request->query->getInt('vWidth'),
 			...$categories
 		);
 	}

--- a/src/Entity/BannerSelection/Campaign.php
+++ b/src/Entity/BannerSelection/Campaign.php
@@ -9,12 +9,14 @@ namespace WMDE\BannerServer\Entity\BannerSelection;
  */
 class Campaign {
 
-	private $identifier;
-	private $start;
-	private $end;
-	private $category;
-	private $rng;
-	private $displayPercentage;
+	private string $identifier;
+	private \DateTime $start;
+	private \DateTime $end;
+	private string $category;
+	private RandomIntegerGenerator $rng;
+	private int $displayPercentage;
+	private ?int $minDisplayWidth;
+	private ?int $maxDisplayWidth;
 
 	/**
 	 * @var Bucket[]
@@ -28,6 +30,8 @@ class Campaign {
 		int $displayPercentage,
 		string $category,
 		RandomIntegerGenerator $rng,
+		?int $minDisplayWidth = null,
+		?int $maxDisplayWidth = null,
 		Bucket $firstBucket,
 		Bucket ...$additionalBuckets ) {
 
@@ -37,6 +41,8 @@ class Campaign {
 		$this->category = $category;
 		$this->displayPercentage = $displayPercentage;
 		$this->rng = $rng;
+		$this->minDisplayWidth = $minDisplayWidth;
+		$this->maxDisplayWidth = $maxDisplayWidth;
 		$this->buckets = array_merge( [$firstBucket], $additionalBuckets );
 	}
 
@@ -68,5 +74,16 @@ class Campaign {
 
 	public function getDisplayPercentage(): int {
 		return $this->displayPercentage;
+	}
+
+	public function isInDisplayRange( int $width): bool {
+
+		if ( $this->minDisplayWidth !== null && $width < $this->minDisplayWidth ) {
+			return false;
+		}
+		if( $this->maxDisplayWidth !== null && $width > $this->maxDisplayWidth ){
+			return false;
+		}
+		return true;
 	}
 }

--- a/src/Entity/BannerSelection/Campaign.php
+++ b/src/Entity/BannerSelection/Campaign.php
@@ -76,7 +76,7 @@ class Campaign {
 		return $this->displayPercentage;
 	}
 
-	public function isInDisplayRange( int $width): bool {
+	public function isInDisplayRange( int $width ): bool {
 
 		if ( $this->minDisplayWidth !== null && $width < $this->minDisplayWidth ) {
 			return false;

--- a/src/Entity/BannerSelection/CampaignCollection.php
+++ b/src/Entity/BannerSelection/CampaignCollection.php
@@ -12,7 +12,7 @@ class CampaignCollection {
 	/**
 	 * @var Campaign[]
 	 */
-	private $campaigns;
+	private array $campaigns;
 
 	public function __construct( Campaign ...$campaigns ) {
 		$this->campaigns = $campaigns;
@@ -25,5 +25,20 @@ class CampaignCollection {
 			}
 		}
 		return null;
+	}
+
+	public function filter( callable $isValid ): CampaignCollection {
+		return new CampaignCollection( ...array_filter( $this->campaigns, $isValid ) );
+	}
+
+	public function getFirstCampaign(): Campaign {
+		if( $this->isEmpty() ) {
+			throw new \OutOfBoundsException("No campaigns found.");
+		}
+		return $this->campaigns[0];
+	}
+
+	public function isEmpty(): bool {
+		return count ( $this->campaigns ) === 0;
 	}
 }

--- a/src/Entity/BannerSelection/CampaignCollection.php
+++ b/src/Entity/BannerSelection/CampaignCollection.php
@@ -33,12 +33,12 @@ class CampaignCollection {
 
 	public function getFirstCampaign(): Campaign {
 		if( $this->isEmpty() ) {
-			throw new \OutOfBoundsException("No campaigns found.");
+			throw new \OutOfBoundsException( 'No campaigns found.' );
 		}
 		return $this->campaigns[0];
 	}
 
 	public function isEmpty(): bool {
-		return count ( $this->campaigns ) === 0;
+		return count( $this->campaigns ) === 0;
 	}
 }

--- a/src/Entity/Visitor.php
+++ b/src/Entity/Visitor.php
@@ -9,18 +9,26 @@ namespace WMDE\BannerServer\Entity;
  */
 class Visitor {
 
-	private $totalImpressionCount = 0;
-	private $bucketIdentifier;
-	private $activeCategories;
+	private int $totalImpressionCount = 0;
+	private ?string $bucketIdentifier;
+	private array $activeCategories;
+	private int $displayWidth;
 
 	/**
 	 * @param int $totalImpressionCount How many banners the visitor has seen overall
 	 * @param string|null $bucketIdentifier Last bucket identifier of the visitor (to put recurring visitors in the same buckets, but only per-campaign)
-	 * @param string ...$activeCategories Categories the user has interacted with (close button, donation, etc)
+	 * @param int|null $minDisplayWidth Minimum window size to display the banner in.
+	 * @param int|null $maxDisplayWidth Maximum window size to display the banner in.
+	 * @param string ...$activeCategories
 	 */
-	public function __construct( int $totalImpressionCount, ?string $bucketIdentifier, string ...$activeCategories ) {
+	public function __construct(
+			int $totalImpressionCount,
+			?string $bucketIdentifier,
+			int $displayWidth,
+			string ...$activeCategories ) {
 		$this->totalImpressionCount = $totalImpressionCount;
 		$this->bucketIdentifier = $bucketIdentifier;
+		$this->displayWidth = $displayWidth;
 		$this->activeCategories = $activeCategories;
 	}
 
@@ -34,6 +42,10 @@ class Visitor {
 
 	public function inCategory( string $categoryName ): bool {
 		return in_array( $categoryName, $this->activeCategories, true );
+	}
+
+	public function getDisplayWidth(): ?int {
+		return $this->displayWidth;
 	}
 
 	/**

--- a/src/Entity/Visitor.php
+++ b/src/Entity/Visitor.php
@@ -17,8 +17,7 @@ class Visitor {
 	/**
 	 * @param int $totalImpressionCount How many banners the visitor has seen overall
 	 * @param string|null $bucketIdentifier Last bucket identifier of the visitor (to put recurring visitors in the same buckets, but only per-campaign)
-	 * @param int|null $minDisplayWidth Minimum window size to display the banner in.
-	 * @param int|null $maxDisplayWidth Maximum window size to display the banner in.
+	 * @param int $displayWidth Viewport width of the visitor's browser window.
 	 * @param string ...$activeCategories
 	 */
 	public function __construct(

--- a/src/Utils/CampaignConfigurationLoader.php
+++ b/src/Utils/CampaignConfigurationLoader.php
@@ -47,6 +47,13 @@ class CampaignConfigurationLoader {
 		if ( empty( $campaignData['start'] ) || empty( $campaignData['end'] ) || !isset( $campaignData['trafficLimit'] ) ) {
 			throw new \DomainException( 'Campaign data is incomplete.' );
 		}
+		if ( is_numeric( $campaignData['minDisplayWidth'] ) && is_numeric( $campaignData['maxDisplayWidth'] ) ) {
+			if ( $campaignData['minDisplayWidth'] > $campaignData['maxDisplayWidth'] ) {
+				throw new \DomainException(
+					'Campaign data display width values are invalid (if defined, max must be higher than min).'
+				);
+			}
+		}
 		return new Campaign(
 			$campaignName,
 			new \DateTime( $campaignData['start'] ),
@@ -54,6 +61,8 @@ class CampaignConfigurationLoader {
 			(int)$campaignData['trafficLimit'],
 			$campaignData['category']?? 'default',
 			new SystemRandomIntegerGenerator(),
+			(int)$campaignData['minDisplayWidth'],
+			(int)$campaignData['maxDisplayWidth'],
 			array_shift( $buckets ),
 			...$buckets
 		);

--- a/tests/Fixtures/CampaignFixture.php
+++ b/tests/Fixtures/CampaignFixture.php
@@ -28,6 +28,8 @@ class CampaignFixture {
 			$displayPercentage,
 			self::TEST_CATEGORY,
 			new SystemRandomIntegerGenerator(),
+			null,
+			null,
 			BucketFixture::getTestBucket()
 		);
 	}
@@ -35,6 +37,26 @@ class CampaignFixture {
 	public static function getTrueRandomTestCampaignCollection( int $displayPercentage = 100 ): CampaignCollection {
 		return new CampaignCollection(
 			self::getTrueRandomTestCampaign( $displayPercentage )
+		);
+	}
+
+	public static function getMaxViewportWidthCampaign( int $maxWidthDesktop ): Campaign {
+		return new Campaign(
+			'C18_WMDE_Test',
+			self::getTestCampaignStartDate(),
+			self::getTestCampaignEndDate(),
+			100,
+			self::TEST_CATEGORY,
+			new SystemRandomIntegerGenerator(),
+			null,
+			$maxWidthDesktop,
+			BucketFixture::getTestBucket()
+		);
+	}
+
+	public static function getFixedViewportWidthCampaignCollection( int $maxViewportWidth ): CampaignCollection {
+		return new CampaignCollection(
+			self::getMaxViewportWidthCampaign( $maxViewportWidth )
 		);
 	}
 }

--- a/tests/Fixtures/VisitorFixture.php
+++ b/tests/Fixtures/VisitorFixture.php
@@ -13,10 +13,11 @@ class VisitorFixture {
 	public const VISITOR_TEST_IMPRESSION_COUNT = 5;
 	public const VISITOR_TEST_BUCKET = 'test_bucket';
 	public const VISITOR_TEST_DONATION_CATEGORY = 'fundraising_2020';
+	public const VISITOR_TEST_DISPLAY_WIDTH = 500;
 
 	public static function getReturningVisitorRequest(): Request {
 		return new Request(
-			[],
+			[ 'vWidth' => self::VISITOR_TEST_DISPLAY_WIDTH ],
 			[],
 			[],
 			[
@@ -30,6 +31,7 @@ class VisitorFixture {
 		return new Visitor(
 			self::VISITOR_TEST_IMPRESSION_COUNT,
 			self::VISITOR_TEST_BUCKET,
+			self::VISITOR_TEST_DISPLAY_WIDTH,
 			self::VISITOR_TEST_DONATION_CATEGORY
 		);
 	}
@@ -37,7 +39,8 @@ class VisitorFixture {
 	public static function getFirstTimeVisitor(): Visitor {
 		return new Visitor(
 			0,
-			null
+			null,
+			0
 		);
 	}
 }

--- a/tests/Fixtures/campaigns/broken_bucket_campaign.yml
+++ b/tests/Fixtures/campaigns/broken_bucket_campaign.yml
@@ -5,6 +5,8 @@ B18WPDE_BROKEN_BUCKET:
   start: "2018-11-31 01:23:45"
   end: "2019-01-01 14:00:00"
   trafficLimit: 10
+  minDisplayWidth: 0
+  maxDisplayWidth: null
   buckets:
   - name:
     banners:

--- a/tests/Fixtures/campaigns/broken_data_campaign.yml
+++ b/tests/Fixtures/campaigns/broken_data_campaign.yml
@@ -4,6 +4,8 @@ B18WPDE_DATA_MISSING:
   description: This campaign is missing a traffic limit
   start: "2018-11-31 01:23:45"
   end: "2019-01-01 14:00:00"
+  minDisplayWidth: 0
+  maxDisplayWidth: null
   buckets:
   - name: B18WPDE_01_180131_ctrl
     banners:

--- a/tests/Fixtures/campaigns/broken_displayWidth_campaign.yml
+++ b/tests/Fixtures/campaigns/broken_displayWidth_campaign.yml
@@ -1,15 +1,17 @@
 # Campaign configuration file for unit tests
 # See campaigns.yml of banner repository for actual campaigns
 B18WPDE_BROKEN_BANNER:
-  description: This campaign is missing banners in a bucket
+  description: This campaign has invalid an invalid min - max amount relation
   start: "2018-11-31 01:23:45"
   end: "2019-01-01 14:00:00"
   trafficLimit: 10
-  minDisplayWidth: 0
-  maxDisplayWidth: null
+  minDisplayWidth: 400
+  maxDisplayWidth: 100
   buckets:
   - name: B18WPDE_01_180131_ctrl
     banners:
+      - B18WPDE_01_180131_fulltop_ctrl
+      - B18WPDE_01_180131_top_ctrl
   - name: B18WPDE_01_180131_var
     banners:
     - B18WPDE_01_180131_fulltop_var

--- a/tests/Fixtures/campaigns/campaigns.yml
+++ b/tests/Fixtures/campaigns/campaigns.yml
@@ -5,6 +5,8 @@ B18WPDE_01_180131:
   start: "2018-11-31 01:23:45"
   end: "2019-01-01 14:00:00"
   trafficLimit: 10
+  minDisplayWidth: 0
+  maxDisplayWidth: 600
   buckets:
     - name: B18WPDE_01_180131_ctrl
       banners:
@@ -24,6 +26,8 @@ B20WPDE_01_201111:
   end: "2020-11-25 14:00:00"
   trafficLimit: 10
   category: fundraising_2020
+  minDisplayWidth: 600
+  maxDisplayWidth: null
   buckets:
     - name: B20WPDE_01_201111_ctrl
       banners:

--- a/tests/Unit/Entity/BannerSelection/CampaignCollectionTest.php
+++ b/tests/Unit/Entity/BannerSelection/CampaignCollectionTest.php
@@ -32,6 +32,8 @@ class CampaignCollectionTest extends TestCase {
 				1,
 				'default',
 				new FakeRandomIntegerGenerator( 1 ),
+				null,
+				null,
 				$this->getTestbucket()
 			),
 			new Campaign(
@@ -41,6 +43,8 @@ class CampaignCollectionTest extends TestCase {
 				1,
 				'default',
 				new FakeRandomIntegerGenerator( 1 ),
+				null,
+				null,
 				$this->getTestbucket()
 			),
 			new Campaign(
@@ -50,6 +54,8 @@ class CampaignCollectionTest extends TestCase {
 				1,
 				'default',
 				new FakeRandomIntegerGenerator( 1 ),
+				null,
+				null,
 				$this->getTestbucket()
 			)
 		);
@@ -68,6 +74,8 @@ class CampaignCollectionTest extends TestCase {
 				1,
 				'default',
 				new FakeRandomIntegerGenerator( 1 ),
+				null,
+				null,
 				$this->getTestbucket()
 			),
 			new Campaign(
@@ -77,6 +85,8 @@ class CampaignCollectionTest extends TestCase {
 				1,
 				'default',
 				new FakeRandomIntegerGenerator( 1 ),
+				null,
+				null,
 				$this->getTestbucket()
 			)
 		);
@@ -87,5 +97,70 @@ class CampaignCollectionTest extends TestCase {
 		);
 
 		$this->assertNull( $campaignCollection->getCampaign( new \DateTime( '2017-09-01 14:00:00' ) ) );
+	}
+
+	public function test_filter_function_drops_invalid_campaigns(): void {
+		$testCampaign1 = new Campaign(
+			'C18_WMDE_Test_present',
+			new \DateTime( '2018-10-01 14:00:00' ),
+			new \DateTime( '2018-10-31 14:00:00' ),
+			1,
+			'default',
+			new FakeRandomIntegerGenerator( 1 ),
+			null,
+			null,
+			$this->getTestbucket()
+		);
+		$testCampaign2 = new Campaign(
+			'C18_WMDE_Test_past',
+			new \DateTime( '1999-10-01 14:00:00' ),
+			new \DateTime( '1999-10-31 14:00:00' ),
+			1,
+			'default',
+			new FakeRandomIntegerGenerator( 1 ),
+			null,
+			null,
+			$this->getTestbucket()
+		);
+
+		$campaignCollection = new CampaignCollection(
+			$testCampaign1,
+			$testCampaign2
+		);
+
+		$filteredCampaignCollection = $campaignCollection->filter(
+			function ( Campaign $campaign ) { return $campaign->getIdentifier() === 'C18_WMDE_Test_past'; }
+			);
+
+		$this->assertSame( $testCampaign2, $filteredCampaignCollection->getFirstCampaign() );
+	}
+
+	public function test_given_empty_collection_then_isEmpty_results_true(): void {
+		$emptyCampaignCollection = new CampaignCollection();
+		$this->assertTrue( $emptyCampaignCollection->isEmpty() );
+	}
+
+	public function test_given_non_empty_collection_then_isEmpty_results_false(): void {
+		$nonEmptyCampaignCollection = new CampaignCollection(
+			new Campaign(
+				'C18_WMDE_Test_past',
+				new \DateTime( '1999-10-01 14:00:00' ),
+				new \DateTime( '1999-10-31 14:00:00' ),
+				1,
+				'default',
+				new FakeRandomIntegerGenerator( 1 ),
+				null,
+				null,
+				$this->getTestbucket()
+			)
+		);
+		$this->assertFalse( $nonEmptyCampaignCollection->isEmpty() );
+	}
+
+	public function test_given_empty_collection_then_get_first_throws_exception(): void {
+		$emptyCampaignCollection = new CampaignCollection();
+
+		$this->expectException( 'OutOfBoundsException' );
+		$emptyCampaignCollection->getFirstCampaign();
 	}
 }

--- a/tests/Unit/Entity/BannerSelection/CampaignCollectionTest.php
+++ b/tests/Unit/Entity/BannerSelection/CampaignCollectionTest.php
@@ -129,7 +129,9 @@ class CampaignCollectionTest extends TestCase {
 		);
 
 		$filteredCampaignCollection = $campaignCollection->filter(
-			function ( Campaign $campaign ) { return $campaign->getIdentifier() === 'C18_WMDE_Test_past'; }
+			function ( Campaign $campaign ) {
+				return $campaign->getIdentifier() === 'C18_WMDE_Test_past';
+			}
 			);
 
 		$this->assertSame( $testCampaign2, $filteredCampaignCollection->getFirstCampaign() );

--- a/tests/Unit/Entity/BannerSelection/CampaignTest.php
+++ b/tests/Unit/Entity/BannerSelection/CampaignTest.php
@@ -178,8 +178,8 @@ class CampaignTest extends TestCase {
 			$this->getVariantBucket()
 		);
 
-		$this->assertTrue( $campaign->isInDisplayRange(0 ) );
-		$this->assertTrue( $campaign->isInDisplayRange(999999 ) );
+		$this->assertTrue( $campaign->isInDisplayRange( 0 ) );
+		$this->assertTrue( $campaign->isInDisplayRange( 999999 ) );
 	}
 
 	public function test_given_desktop_campaign_then_width_is_limited(): void {
@@ -196,9 +196,9 @@ class CampaignTest extends TestCase {
 			$this->getVariantBucket()
 		);
 
-		$this->assertFalse( $campaign->isInDisplayRange(1024 ) );
-		$this->assertTrue( $campaign->isInDisplayRange(1025 ) );
-		$this->assertTrue( $campaign->isInDisplayRange(999999 ) );
+		$this->assertFalse( $campaign->isInDisplayRange( 1024 ) );
+		$this->assertTrue( $campaign->isInDisplayRange( 1025 ) );
+		$this->assertTrue( $campaign->isInDisplayRange( 999999 ) );
 	}
 
 	public function test_given_mobile_campaign_then_width_is_limited(): void {
@@ -215,8 +215,8 @@ class CampaignTest extends TestCase {
 			$this->getVariantBucket()
 		);
 
-		$this->assertTrue( $campaign->isInDisplayRange(0 ) );
-		$this->assertTrue( $campaign->isInDisplayRange(1024 ) );
-		$this->assertFalse( $campaign->isInDisplayRange(1025 ) );
+		$this->assertTrue( $campaign->isInDisplayRange( 0 ) );
+		$this->assertTrue( $campaign->isInDisplayRange( 1024 ) );
+		$this->assertFalse( $campaign->isInDisplayRange( 1025 ) );
 	}
 }

--- a/tests/Unit/Entity/BannerSelection/CampaignTest.php
+++ b/tests/Unit/Entity/BannerSelection/CampaignTest.php
@@ -39,6 +39,8 @@ class CampaignTest extends TestCase {
 			1,
 			'default',
 			new FakeRandomIntegerGenerator( 1 ),
+			null,
+			null,
 			$this->getControlBucket(),
 			$this->getVariantBucket()
 		);
@@ -65,6 +67,8 @@ class CampaignTest extends TestCase {
 			1,
 			'default',
 			new FakeRandomIntegerGenerator( 1 ),
+			null,
+			null,
 			$this->getControlBucket(),
 			$this->getVariantBucket()
 		);
@@ -90,6 +94,8 @@ class CampaignTest extends TestCase {
 			1,
 			'default',
 			new FakeRandomIntegerGenerator( 1 ),
+			null,
+			null,
 			$this->getControlBucket(),
 			$this->getVariantBucket()
 		);
@@ -107,6 +113,8 @@ class CampaignTest extends TestCase {
 			1,
 			'default',
 			new FakeRandomIntegerGenerator( 1 ),
+			null,
+			null,
 			$this->getControlBucket(),
 			$this->getVariantBucket()
 		);
@@ -124,6 +132,8 @@ class CampaignTest extends TestCase {
 			1,
 			'default',
 			new FakeRandomIntegerGenerator( 1 ),
+			null,
+			null,
 			$this->getControlBucket(),
 			$this->getVariantBucket()
 		);
@@ -144,11 +154,69 @@ class CampaignTest extends TestCase {
 			$displayPercentage,
 			'default',
 			new FakeRandomIntegerGenerator( 1 ),
+			null,
+			null,
 			$this->getControlBucket(),
 			$this->getVariantBucket()
 		);
 		$this->assertEquals( $identifier, $campaign->getIdentifier() );
 		$this->assertEquals( $displayPercentage, $campaign->getDisplayPercentage() );
 		$this->assertEquals( $endDate, $campaign->getEnd() );
+	}
+
+	public function test_given_no_mindisplaywidth_and_no_maxdisplaywidth_then_width_is_always_in_range(): void {
+		$campaign = new Campaign(
+			'C18_WMDE_Test',
+			new \DateTime( '2018-10-01 14:00:00' ),
+			new \DateTime( '2018-10-31 14:00:00' ),
+			1,
+			'default',
+			new FakeRandomIntegerGenerator( 1 ),
+			null,
+			null,
+			$this->getControlBucket(),
+			$this->getVariantBucket()
+		);
+
+		$this->assertTrue( $campaign->isInDisplayRange(0 ) );
+		$this->assertTrue( $campaign->isInDisplayRange(999999 ) );
+	}
+
+	public function test_given_desktop_campaign_then_width_is_limited(): void {
+		$campaign = new Campaign(
+			'C18_WMDE_Test',
+			new \DateTime( '2018-10-01 14:00:00' ),
+			new \DateTime( '2018-10-31 14:00:00' ),
+			1,
+			'default',
+			new FakeRandomIntegerGenerator( 1 ),
+			1025,
+			null,
+			$this->getControlBucket(),
+			$this->getVariantBucket()
+		);
+
+		$this->assertFalse( $campaign->isInDisplayRange(1024 ) );
+		$this->assertTrue( $campaign->isInDisplayRange(1025 ) );
+		$this->assertTrue( $campaign->isInDisplayRange(999999 ) );
+	}
+
+	public function test_given_mobile_campaign_then_width_is_limited(): void {
+		$campaign = new Campaign(
+			'C18_WMDE_Test',
+			new \DateTime( '2018-10-01 14:00:00' ),
+			new \DateTime( '2018-10-31 14:00:00' ),
+			1,
+			'default',
+			new FakeRandomIntegerGenerator( 1 ),
+			null,
+			1024,
+			$this->getControlBucket(),
+			$this->getVariantBucket()
+		);
+
+		$this->assertTrue( $campaign->isInDisplayRange(0 ) );
+		$this->assertTrue( $campaign->isInDisplayRange(1024 ) );
+		$this->assertFalse( $campaign->isInDisplayRange(1025 ) );
 	}
 }

--- a/tests/Unit/Entity/VisitorTest.php
+++ b/tests/Unit/Entity/VisitorTest.php
@@ -14,16 +14,25 @@ class VisitorTest extends TestCase {
 
 	const TEST_IMPRESSION_COUNT = 2;
 	const TEST_BUCKET = 'TEST_BUCKET123';
+	const TEST_DISPLAY_WIDTH = 500;
 
 	public function test_given_visitor_without_categories_then_correct_values_are_returned(): void {
-		$visitor = new Visitor( self::TEST_IMPRESSION_COUNT, self::TEST_BUCKET );
+		$visitor = new Visitor(
+			self::TEST_IMPRESSION_COUNT,
+			self::TEST_BUCKET,
+			self::TEST_DISPLAY_WIDTH);
 		$this->assertEquals( self::TEST_IMPRESSION_COUNT, $visitor->getTotalImpressionCount() );
 		$this->assertEquals( self::TEST_BUCKET, $visitor->getBucketIdentifier() );
 		$this->assertFalse( $visitor->inCategory( 'default' ) );
 	}
 
 	public function test_given_visitor_with_categories_then_correct_values_are_returned(): void {
-		$visitor = new Visitor( self::TEST_IMPRESSION_COUNT, self::TEST_BUCKET, 'default', 'fundraising_2020' );
+		$visitor = new Visitor(
+			self::TEST_IMPRESSION_COUNT,
+			self::TEST_BUCKET,
+			self::TEST_DISPLAY_WIDTH,
+			'default',
+			'fundraising_2020' );
 		$this->assertTrue( $visitor->inCategory( 'default' ) );
 		$this->assertTrue( $visitor->inCategory( 'fundraising_2020' ) );
 		$this->assertFalse( $visitor->inCategory( 'dummy_category' ) );

--- a/tests/Unit/UseCase/BannerSelection/BannerSelectionUseCaseTest.php
+++ b/tests/Unit/UseCase/BannerSelection/BannerSelectionUseCaseTest.php
@@ -108,7 +108,7 @@ class BannerSelectionUseCaseTest extends TestCase {
 	}
 
 
-	public function test_given_display_width_range_filters_banners():void {
+	public function test_given_display_width_range_filters_banners(): void {
 		$smallMobileMaxWidth = 400;
 
 		$useCase = new BannerSelectionUseCase(

--- a/tests/Unit/UseCase/BannerSelection/BannerSelectionUseCaseTest.php
+++ b/tests/Unit/UseCase/BannerSelection/BannerSelectionUseCaseTest.php
@@ -65,7 +65,12 @@ class BannerSelectionUseCaseTest extends TestCase {
 			new ImpressionThreshold( 10 ),
 			new SystemRandomIntegerGenerator()
 		);
-		$visitor = new Visitor( 0, null, CampaignFixture::TEST_CATEGORY, 'another-irrelevant-category' );
+		$visitor = new Visitor( 0,
+			null,
+			500,
+			CampaignFixture::TEST_CATEGORY,
+			'another-irrelevant-category'
+		);
 
 		$bannerSelectionData = $useCase->selectBanner( $visitor );
 
@@ -101,4 +106,24 @@ class BannerSelectionUseCaseTest extends TestCase {
 			$bannerSelectionData->getVisitorData()->getTotalImpressionCount()
 		);
 	}
+
+
+	public function test_given_display_width_range_filters_banners():void {
+		$smallMobileMaxWidth = 400;
+
+		$useCase = new BannerSelectionUseCase(
+			CampaignFixture::getFixedViewportWidthCampaignCollection( $smallMobileMaxWidth ),
+			new ImpressionThreshold( 10 ),
+			new SystemRandomIntegerGenerator()
+		);
+
+		$bannerSelectionData = $useCase->selectBanner( VisitorFixture::getTestVisitor() );
+
+		$this->assertFalse( $bannerSelectionData->displayBanner(),
+			'No banner should be selected, because campaign was for mobile, visitor was desktop width.' );
+	}
+
+
+
+
 }

--- a/tests/Unit/Utils/CampaignConfigurationLoaderTest.php
+++ b/tests/Unit/Utils/CampaignConfigurationLoaderTest.php
@@ -71,7 +71,7 @@ class CampaignConfigurationLoaderTest extends TestCase {
 		$loader = new CampaignConfigurationLoader(
 			self::TEST_BROKEN_DISPLAYWIDTH_CAMPAIGN_CONFIGURATION_FILE
 		);
-		$this->expectExceptionMessage('Campaign data display width values are invalid (if defined, max must be higher than min)');
+		$this->expectExceptionMessage( 'Campaign data display width values are invalid (if defined, max must be higher than min)' );
 		$loader->getCampaignCollection();
 	}
 

--- a/tests/Unit/Utils/CampaignConfigurationLoaderTest.php
+++ b/tests/Unit/Utils/CampaignConfigurationLoaderTest.php
@@ -17,6 +17,7 @@ class CampaignConfigurationLoaderTest extends TestCase {
 	const TEST_BROKEN_BUCKET_CAMPAIGN_CONFIGURATION_FILE = 'tests/Fixtures/campaigns/broken_bucket_campaign.yml';
 	const TEST_BROKEN_BANNER_CAMPAIGN_CONFIGURATION_FILE = 'tests/Fixtures/campaigns/broken_banner_campaign.yml';
 	const TEST_BROKEN_DATA_CAMPAIGN_CONFIGURATION_FILE = 'tests/Fixtures/campaigns/broken_data_campaign.yml';
+	const TEST_BROKEN_DISPLAYWIDTH_CAMPAIGN_CONFIGURATION_FILE = 'tests/Fixtures/campaigns/broken_displayWidth_campaign.yml';
 
 	public function test_given_campaigns_are_loaded_then_loaded_campaign_data_is_correct(): void {
 		$loader = new CampaignConfigurationLoader( self::TEST_VALID_CAMPAIGN_CONFIGURATION_FILE );
@@ -63,6 +64,14 @@ class CampaignConfigurationLoaderTest extends TestCase {
 			self::TEST_BROKEN_DATA_CAMPAIGN_CONFIGURATION_FILE
 		);
 		$this->expectExceptionMessage( 'Campaign data is incomplete.' );
+		$loader->getCampaignCollection();
+	}
+
+	public function test_given_display_widths_max_is_larger_than_min_or_undefined(): void {
+		$loader = new CampaignConfigurationLoader(
+			self::TEST_BROKEN_DISPLAYWIDTH_CAMPAIGN_CONFIGURATION_FILE
+		);
+		$this->expectExceptionMessage('Campaign data display width values are invalid (if defined, max must be higher than min)');
 		$loader->getCampaignCollection();
 	}
 


### PR DESCRIPTION
Adds 2 private fields to the campaign class.
The 2 values are the range of vieport width in which this campaign should be active.

https://phabricator.wikimedia.org/T253535