### PR TITLE
Remove 1px gap on banner selection by width

### DIFF
--- a/src/Entity/BannerSelection/Campaign.php
+++ b/src/Entity/BannerSelection/Campaign.php
@@ -79,7 +79,7 @@ class Campaign {
 		if ( $this->minDisplayWidth !== null && $width < $this->minDisplayWidth ) {
 			return false;
 		}
-		if ( $this->maxDisplayWidth !== null && $width > $this->maxDisplayWidth ) {
+		if ( $this->maxDisplayWidth !== null && $width >= $this->maxDisplayWidth ) {
 			return false;
 		}
 		return true;

--- a/tests/Fixtures/BucketFixture.php
+++ b/tests/Fixtures/BucketFixture.php
@@ -11,10 +11,10 @@ class BucketFixture {
 	public const TEST_BUCKET_IDENTIFIER = 'test';
 	public const TEST_BANNER_IDENTIFIER = 'TestBanner';
 
-	public static function getTestbucket(): Bucket {
+	public static function getTestbucket( ?string $bannerIdentifier = null ): Bucket {
 		return new Bucket(
 			self::TEST_BUCKET_IDENTIFIER,
-			new Banner( self::TEST_BANNER_IDENTIFIER )
+			new Banner( $bannerIdentifier ?? self::TEST_BANNER_IDENTIFIER )
 		);
 	}
 }

--- a/tests/Fixtures/CampaignFixture.php
+++ b/tests/Fixtures/CampaignFixture.php
@@ -40,7 +40,7 @@ class CampaignFixture {
 		);
 	}
 
-	public static function getMaxViewportWidthCampaign( int $maxWidthDesktop ): Campaign {
+	public static function getMaxViewportWidthCampaign( int $maxWidthDesktop, ?string $bannerIdentifier = null ): Campaign {
 		return new Campaign(
 			'C18_WMDE_Test',
 			self::getTestCampaignStartDate(),
@@ -50,13 +50,34 @@ class CampaignFixture {
 			new SystemRandomIntegerGenerator(),
 			null,
 			$maxWidthDesktop,
-			BucketFixture::getTestBucket()
+			BucketFixture::getTestBucket( $bannerIdentifier )
+		);
+	}
+
+	public static function getMinViewportWidthCampaign( int $minWidth, ?string $bannerIdentifier = null ): Campaign {
+		return new Campaign(
+			'C18_WMDE_Test',
+			self::getTestCampaignStartDate(),
+			self::getTestCampaignEndDate(),
+			100,
+			self::TEST_CATEGORY,
+			new SystemRandomIntegerGenerator(),
+			$minWidth,
+			null,
+			BucketFixture::getTestBucket( $bannerIdentifier )
 		);
 	}
 
 	public static function getFixedViewportWidthCampaignCollection( int $maxViewportWidth ): CampaignCollection {
 		return new CampaignCollection(
 			self::getMaxViewportWidthCampaign( $maxViewportWidth )
+		);
+	}
+
+	public static function getMixedFixedViewportWidthCampaignCollection( int $minViewportWidth, int $maxViewportWidth, string $minIdentifier, string $maxIdentifier ): CampaignCollection {
+		return new CampaignCollection(
+			self::getMinViewportWidthCampaign( $minViewportWidth, $minIdentifier ),
+			self::getMaxViewportWidthCampaign( $maxViewportWidth, $maxIdentifier )
 		);
 	}
 }

--- a/tests/Fixtures/VisitorFixture.php
+++ b/tests/Fixtures/VisitorFixture.php
@@ -27,11 +27,11 @@ class VisitorFixture {
 		);
 	}
 
-	public static function getTestVisitor(): Visitor {
+	public static function getTestVisitor( ?int $displayWidth = null ): Visitor {
 		return new Visitor(
 			self::VISITOR_TEST_IMPRESSION_COUNT,
 			self::VISITOR_TEST_BUCKET,
-			self::VISITOR_TEST_DISPLAY_WIDTH,
+			$displayWidth ?? self::VISITOR_TEST_DISPLAY_WIDTH,
 			self::VISITOR_TEST_DONATION_CATEGORY
 		);
 	}

--- a/tests/Unit/Entity/BannerSelection/CampaignTest.php
+++ b/tests/Unit/Entity/BannerSelection/CampaignTest.php
@@ -215,7 +215,7 @@ class CampaignTest extends TestCase {
 		);
 
 		$this->assertTrue( $campaign->isInDisplayRange( 0 ) );
-		$this->assertTrue( $campaign->isInDisplayRange( 1024 ) );
-		$this->assertFalse( $campaign->isInDisplayRange( 1025 ) );
+		$this->assertTrue( $campaign->isInDisplayRange( 1023 ) );
+		$this->assertFalse( $campaign->isInDisplayRange( 1024 ) );
 	}
 }

--- a/tests/Unit/UseCase/BannerSelection/BannerSelectionUseCaseTest.php
+++ b/tests/Unit/UseCase/BannerSelection/BannerSelectionUseCaseTest.php
@@ -122,4 +122,22 @@ class BannerSelectionUseCaseTest extends TestCase {
 			'No banner should be selected, because campaign was for mobile, visitor was desktop width.' );
 	}
 
+	public function test_given_display_width_range_with_multiple_banners_selects_correct_banner(): void {
+		$desktopMinWidth = 600;
+		$desktopIdentifier = 'C20_WMDE_Test_01';
+		$mobileMaxWidth = 600;
+		$mobileIdentifier = 'C20_WMDE_Test_Mobile_01';
+
+		$useCase = new BannerSelectionUseCase(
+			CampaignFixture::getMixedFixedViewportWidthCampaignCollection( $desktopMinWidth, $mobileMaxWidth, $desktopIdentifier, $mobileIdentifier ),
+			new ImpressionThreshold( 10 ),
+			new SystemRandomIntegerGenerator()
+		);
+
+		$desktopSelectionData = $useCase->selectBanner( VisitorFixture::getTestVisitor( 1000 ) );
+		$mobileSelectionData = $useCase->selectBanner( VisitorFixture::getTestVisitor( 320 ) );
+
+		$this->assertEquals( $desktopIdentifier, $desktopSelectionData->getBannerIdentifier() );
+		$this->assertEquals( $mobileIdentifier, $mobileSelectionData->getBannerIdentifier() );
+	}
 }


### PR DESCRIPTION
This removes the 1px gap between mobile and desktop banners.
It also add a test to make sure that the correct banner is selected when there is a mobile and desktop campaign running at the same time.