### PR TITLE
Cast string inputs to int

### DIFF
--- a/src/Controller/AbstractCookieController.php
+++ b/src/Controller/AbstractCookieController.php
@@ -18,7 +18,7 @@ abstract class AbstractCookieController {
 	}
 
 	public function index( Request $request ): Response {
-		$categories = trim( $request->query->get( self::CATEGORY_PARAM, '' ) );
+		$categories = trim( (string)$request->query->get( self::CATEGORY_PARAM, '' ) );
 		if ( $categories === '' || !preg_match( '/^[-0-9a-zA-Z_,]+$/', $categories ) ) {
 			return $this->newHtmlResponse( 'No donation category specified', Response::HTTP_BAD_REQUEST );
 		}

--- a/src/Controller/BannerSelectionController.php
+++ b/src/Controller/BannerSelectionController.php
@@ -52,11 +52,11 @@ class BannerSelectionController {
 	}
 
 	private function buildValuesFromRequest( Request $request ): Visitor {
-		$rawCategories = $request->cookies->get( self::CATEGORY_COOKIE, '' );
+		$rawCategories = $request->cookies->get( (string)self::CATEGORY_COOKIE, '' );
 		$categories = array_filter( explode( ',', $rawCategories ) );
 		return new Visitor(
 			$request->cookies->getInt( self::IMPRESSION_COUNT_COOKIE, 0 ),
-			$request->cookies->get( self::BUCKET_COOKIE, null ),
+			(string)$request->cookies->get( self::BUCKET_COOKIE, null ) ?: null,
 			$request->query->getInt( 'vWidth' ),
 			...$categories
 		);


### PR DESCRIPTION
The `ParameterBag::get` method has a mixed return type, while our
the functions expect string or null values. We cast the inputs to
strings to avoid warnings from static analysis.
