### PR TITLE
Update PHP and Xdebug

### DIFF
--- a/build/app/Dockerfile
+++ b/build/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-fpm as app
+FROM php:8.0-fpm-buster as app
 
 RUN mkdir -p /usr/share/nginx/www/banner.wikipedia.de/current/var/cache \
     && mkdir -p /usr/share/nginx/www/banner.wikipedia.de/current/var/log \
@@ -13,7 +13,7 @@ RUN curl https://getcomposer.org/installer | php -- --filename=composer --instal
 
 FROM app as app_debug
 
-RUN pecl install xdebug-2.9.1 \
+RUN pecl install xdebug-3.0.4 \
     && docker-php-ext-enable xdebug \
     && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -14,6 +14,7 @@ services:
       context: ./build/app
       target: app_debug
     environment:
+      - XDEBUG_MODE=coverage
       - XDEBUG_CONFIG=remote_host=${LOCAL_IP} # This won't work for PHPStorm CLI runs until https://youtrack.jetbrains.com/issue/WI-41043 is fixed
       - PHP_IDE_CONFIG=serverName=banner.wikipedia.de
     expose:


### PR DESCRIPTION
Update PHP to 8 and Xdebug to 3

This update fixes our CI failures while building the Docker image. The
newest Debian version ("bullseye") has a problem when building PHP, so
we fix the underlying version to the previous one ("buster").

The CI environment seems to be fine, but we haven't tested the server
yet and it still runs on PHP 7.4 in production.

Our current Symfony version 4 might not be compatible with PHP 8 so this
is a preliminary commit to avoid the piling-up of failed dependabot pull
requests.
