### PR TITLE
Add Maybe Later cookie controller

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -9,3 +9,7 @@ banner_server_finish_donation:
 banner_server_close_banner:
   path: /close-banner
   controller: WMDE\BannerServer\Controller\BannerClosedController::index
+
+banner_server_maybe_later:
+  path: /maybe-later
+  controller: WMDE\BannerServer\Controller\MaybeLaterController::index

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -45,6 +45,11 @@ services:
             $cookieLifetime: 'P7D'
         tags: ['controller.service_arguments']
 
+    WMDE\BannerServer\Controller\MaybeLaterController:
+        arguments:
+            $cookieLifetime: 'P6H'
+        tags: [ 'controller.service_arguments' ]
+
     WMDE\BannerServer\Entity\BannerSelection\CampaignCollection:
         factory: ['@WMDE\BannerServer\Utils\CampaignConfigurationLoader', 'getCampaignCollection']
 

--- a/src/Controller/MaybeLaterController.php
+++ b/src/Controller/MaybeLaterController.php
@@ -1,0 +1,9 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\BannerServer\Controller;
+
+class MaybeLaterController extends AbstractCookieController {
+
+}


### PR DESCRIPTION
Hitting maybe later on a banner's soft close should now add a 6 hour cookie on the banner server

Ticket: https://phabricator.wikimedia.org/T352509