### PR TITLE
Require coverage metadata in PHPUnit config

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php" cacheDirectory=".phpunit.cache">
+<phpunit
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd"
+	backupGlobals="false"
+	colors="true"
+	bootstrap="vendor/autoload.php"
+	cacheDirectory=".phpunit.cache"
+	stopOnError="false"
+	stopOnFailure="false"
+	stopOnIncomplete="false"
+	backupStaticProperties="false"
+>
   <coverage/>
   <php>
     <ini name="error_reporting" value="-1"/>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,7 @@
 	stopOnFailure="false"
 	stopOnIncomplete="false"
 	backupStaticProperties="false"
+	requireCoverageMetadata="true"
 >
   <coverage/>
   <php>


### PR DESCRIPTION
PHPUnit should check for `@covers` annotations and/or `#CoversClass` PHP
attributes. This change will allow us to disable the check in our coding
style, which only supports annotations. The coding style rule would
block us from using attributes and PHPUnit 11 in the future.

Ticket: https://phabricator.wikimedia.org/T359971