### PR TITLE
Fix broken "maybe later" cookie interval

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -47,7 +47,7 @@ services:
 
     WMDE\BannerServer\Controller\MaybeLaterController:
         arguments:
-            $cookieLifetime: 'P6H'
+            $cookieLifetime: 'PT6H'
         tags: [ 'controller.service_arguments' ]
 
     WMDE\BannerServer\Entity\BannerSelection\CampaignCollection:


### PR DESCRIPTION
The interval was invalid, leading to errors instead of a cookie being
set when the donor clicks on "maybe later" in the soft-close banner in
wikipedia.de
