### PR TITLE
Add route for "Already Donated" cookie

### DIFF
--- a/build/app/Dockerfile
+++ b/build/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-fpm-buster as app
+FROM php:8.3-fpm as app
 
 RUN mkdir -p /usr/share/nginx/www/banner.wikipedia.de/current/var/cache \
     && mkdir -p /usr/share/nginx/www/banner.wikipedia.de/current/var/log \
@@ -13,7 +13,7 @@ RUN curl https://getcomposer.org/installer | php -- --filename=composer --instal
 
 FROM app as app_debug
 
-RUN pecl install xdebug-3.1.2 \
+RUN pecl install xdebug-3.3.2 \
     && docker-php-ext-enable xdebug \
     && echo "xdebug.remote_enable=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.remote_autostart=off" >> /usr/local/etc/php/conf.d/xdebug.ini

--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -13,3 +13,7 @@ banner_server_close_banner:
 banner_server_maybe_later:
   path: /maybe-later
   controller: WMDE\BannerServer\Controller\MaybeLaterController::index
+
+banner_server_already_donated:
+  path: /already-donated
+  controller: WMDE\BannerServer\Controller\AlreadyDonatedController::index

--- a/src/Controller/AbstractCookieController.php
+++ b/src/Controller/AbstractCookieController.php
@@ -11,12 +11,6 @@ use Symfony\Component\HttpFoundation\Response;
 abstract class AbstractCookieController {
 	public const CATEGORY_PARAM = 'c';
 
-	protected string $cookieLifetime;
-
-	public function __construct( string $cookieLifetime ) {
-		$this->cookieLifetime = $cookieLifetime;
-	}
-
 	public function index( Request $request ): Response {
 		$categories = trim( (string)$request->query->get( self::CATEGORY_PARAM, '' ) );
 		if ( $categories === '' || !preg_match( '/^[-0-9a-zA-Z_,]+$/', $categories ) ) {
@@ -28,7 +22,7 @@ abstract class AbstractCookieController {
 			$response = $this->newHtmlResponse( 'Thank you for donating' );
 		}
 
-		$expiry = ( new \DateTime() )->add( new \DateInterval( $this->cookieLifetime ) );
+		$expiry = ( new \DateTime() )->add( $this->getCookieLifetime() );
 		$response->headers->setCookie( Cookie::create(
 			BannerSelectionController::CATEGORY_COOKIE,
 			$categories,
@@ -42,6 +36,8 @@ abstract class AbstractCookieController {
 		) );
 		return $response;
 	}
+
+	abstract protected function getCookieLifetime(): \DateInterval;
 
 	private function newHtmlResponse( string $message, int $status = Response::HTTP_OK ): Response {
 		$html = "<!DOCTYPE html><html lang='en'><head><title>WMDE Banner Server</title>" .

--- a/src/Controller/AbstractCookieControllerWithFixedLifetime.php
+++ b/src/Controller/AbstractCookieControllerWithFixedLifetime.php
@@ -1,0 +1,18 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\BannerServer\Controller;
+
+abstract class AbstractCookieControllerWithFixedLifetime extends AbstractCookieController {
+
+	private readonly \DateInterval $cookieLifetime;
+
+	public function __construct( string $cookieLifetime ) {
+		$this->cookieLifetime = new \DateInterval( $cookieLifetime );
+	}
+
+	protected function getCookieLifetime(): \DateInterval {
+		return $this->cookieLifetime;
+	}
+}

--- a/src/Controller/AlreadyDonatedController.php
+++ b/src/Controller/AlreadyDonatedController.php
@@ -1,0 +1,45 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace WMDE\BannerServer\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * This controller allows to set the cookie lifetime dynamically with the "d" (="duration") query parameter.
+ */
+class AlreadyDonatedController extends AbstractCookieController {
+
+	public const MAX_INTERVAL_LENGTH = 'P28D';
+
+	private \DateInterval $cookieLifetime;
+
+	public function __construct() {
+		$this->cookieLifetime = new \DateInterval( self::MAX_INTERVAL_LENGTH );
+	}
+
+	public function index( Request $request ): Response {
+		if ( $request->query->has( 'd' ) ) {
+			$potentialLifetime = $this->getDurationHours( $request->query->get( 'd' ) );
+			$now = new \DateTimeImmutable();
+			if ( $now->add( $potentialLifetime ) < $now->add( new \DateInterval( self::MAX_INTERVAL_LENGTH ) ) ) {
+				$this->cookieLifetime = $potentialLifetime;
+			}
+		}
+		return parent::index( $request );
+	}
+
+	protected function getCookieLifetime(): \DateInterval {
+		return $this->cookieLifetime;
+	}
+
+	private function getDurationHours( float|bool|int|string|null $durationInHours ): \DateInterval {
+		$durationInHours = filter_var( $durationInHours, FILTER_VALIDATE_INT );
+		if ( $durationInHours === false ) {
+			return new \DateInterval( self::MAX_INTERVAL_LENGTH );
+		}
+		return new \DateInterval( 'PT' . $durationInHours . 'H' );
+	}
+}

--- a/src/Controller/BannerClosedController.php
+++ b/src/Controller/BannerClosedController.php
@@ -4,6 +4,6 @@ declare( strict_types = 1 );
 
 namespace WMDE\BannerServer\Controller;
 
-class BannerClosedController extends AbstractCookieController {
+class BannerClosedController extends AbstractCookieControllerWithFixedLifetime {
 
 }

--- a/src/Controller/DonationFinishedController.php
+++ b/src/Controller/DonationFinishedController.php
@@ -4,9 +4,6 @@ declare( strict_types = 1 );
 
 namespace WMDE\BannerServer\Controller;
 
-/**
- * @license GPL-2.0-or-later
- */
-class DonationFinishedController extends AbstractCookieController {
+class DonationFinishedController extends AbstractCookieControllerWithFixedLifetime {
 
 }

--- a/src/Controller/MaybeLaterController.php
+++ b/src/Controller/MaybeLaterController.php
@@ -4,6 +4,6 @@ declare( strict_types = 1 );
 
 namespace WMDE\BannerServer\Controller;
 
-class MaybeLaterController extends AbstractCookieController {
+class MaybeLaterController extends AbstractCookieControllerWithFixedLifetime {
 
 }

--- a/tests/Unit/Controller/AlreadyDonatedControllerTest.php
+++ b/tests/Unit/Controller/AlreadyDonatedControllerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace WMDE\BannerServer\Tests\Unit\Controller;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use WMDE\BannerServer\Controller\AlreadyDonatedController;
+
+#[CoversClass( AlreadyDonatedController::class )]
+class AlreadyDonatedControllerTest extends TestCase {
+
+	public function test_given_no_parameter_controller_defaults_to_maximum_lifetime(): void {
+		$controller = new AlreadyDonatedController();
+
+		$response = $controller->index( new Request( [ 'c' => 'fundraising' ] ) );
+
+		$this->assertSame( Response::HTTP_OK, $response->getStatusCode() );
+		$firstCookie = $response->headers->getCookies( ResponseHeaderBag::COOKIES_FLAT )[0];
+		$expectedDate = ( new \DateTime() )->add( new \DateInterval( AlreadyDonatedController::MAX_INTERVAL_LENGTH ) );
+
+		$this->assertEqualsWithDelta( $expectedDate->getTimestamp(), $firstCookie->getExpiresTime(), 5 );
+	}
+
+	public function test_given_a_parameter_controller_defaults_to_parameter_lifetime_in_hours(): void {
+		$controller = new AlreadyDonatedController();
+
+		$response = $controller->index( new Request( [ 'c' => 'fundraising', 'd' => '48' ] ) );
+
+		$this->assertSame( Response::HTTP_OK, $response->getStatusCode() );
+		$firstCookie = $response->headers->getCookies( ResponseHeaderBag::COOKIES_FLAT )[0];
+		$expectedDate = ( new \DateTime() )->add( new \DateInterval( 'PT48H' ) );
+
+		$this->assertEqualsWithDelta( $expectedDate->getTimestamp(), $firstCookie->getExpiresTime(), 5 );
+	}
+
+	public function test_given_a_parameter_that_exceeds_maximum_duration_controller_defaults_to_maximum_lifetime(): void {
+		$controller = new AlreadyDonatedController();
+
+		$response = $controller->index( new Request( [ 'c' => 'fundraising', 'd' => 6 * 7 * 24 ] ) );
+
+		$this->assertSame( Response::HTTP_OK, $response->getStatusCode() );
+		$firstCookie = $response->headers->getCookies( ResponseHeaderBag::COOKIES_FLAT )[0];
+		$expectedDate = ( new \DateTime() )->add( new \DateInterval( AlreadyDonatedController::MAX_INTERVAL_LENGTH ) );
+
+		$this->assertEqualsWithDelta( $expectedDate->getTimestamp(), $firstCookie->getExpiresTime(), 5 );
+	}
+
+	public function test_given_a_parameter_with_invalid_value_controller_defaults_to_maximum_lifetime(): void {
+		$controller = new AlreadyDonatedController();
+
+		$response = $controller->index( new Request( [ 'c' => 'fundraising', 'd' => 'forever' ] ) );
+
+		$this->assertSame( Response::HTTP_OK, $response->getStatusCode() );
+		$firstCookie = $response->headers->getCookies( ResponseHeaderBag::COOKIES_FLAT )[0];
+		$expectedDate = ( new \DateTime() )->add( new \DateInterval( AlreadyDonatedController::MAX_INTERVAL_LENGTH ) );
+
+		$this->assertEqualsWithDelta( $expectedDate->getTimestamp(), $firstCookie->getExpiresTime(), 5 );
+	}
+
+}

--- a/tests/Utils/TestCookieController.php
+++ b/tests/Utils/TestCookieController.php
@@ -4,8 +4,8 @@ declare( strict_types = 1 );
 
 namespace WMDE\BannerServer\Tests\Utils;
 
-use WMDE\BannerServer\Controller\AbstractCookieController;
+use WMDE\BannerServer\Controller\AbstractCookieControllerWithFixedLifetime;
 
-class TestCookieController extends AbstractCookieController {
+class TestCookieController extends AbstractCookieControllerWithFixedLifetime {
 
 }


### PR DESCRIPTION
- Update PHP to 8.3
- Refactor AbstractCookieController
- Add new route for "Already donated" cookie: `/already-donated`


https://phabricator.wikimedia.org/T375609
https://phabricator.wikimedia.org/T376792
