### PR TITLE
Require Symfony v7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -79,7 +79,7 @@
     "extra": {
         "symfony": {
             "allow-contrib": true,
-            "require": "^6.0"
+            "require": "^7.2"
         }
     }
 }

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,8 @@
 parameters:
 	inferPrivatePropertyTypeFromConstructor: true
-	checkMissingIterableValueType: false
+	ignoreErrors:
+		-
+			identifier: missingType.iterableValue
 
 includes:
 	- vendor/phpstan/phpstan-phpunit/extension.neon

--- a/phpstan.prod.neon
+++ b/phpstan.prod.neon
@@ -1,4 +1,5 @@
 parameters:
 	inferPrivatePropertyTypeFromConstructor: true
-	checkMissingIterableValueType: false
-
+	ignoreErrors:
+		-
+			identifier: missingType.iterableValue

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,6 +1,7 @@
 <?php
 
 use Symfony\Component\Dotenv\Dotenv;
+use Symfony\Component\ErrorHandler\ErrorHandler;
 
 require dirname( __DIR__ ) . '/vendor/autoload.php';
 
@@ -9,3 +10,10 @@ if ( file_exists( dirname( __DIR__ ) . '/config/bootstrap.php' ) ) {
 } elseif ( method_exists( Dotenv::class, 'bootEnv' ) ) {
 	( new Dotenv() )->bootEnv( dirname( __DIR__ ) . '/.env' );
 }
+
+// Workaround for https://github.com/symfony/symfony/issues/53812
+// The problem is that FrameworkBundle registers an error handler but does not have a way to unregister it.
+// The issue was closed, so we probably need to use the workaround until newer Symfony/PHPUnit versions fix it,
+// or we use the regular Symfony WebTestCase instead of our custom WebRouteTestCase.
+// The current setup code in FrameworkBundle will check if `ErrorHandler` is already registered and won't register it again.
+set_exception_handler( [ new ErrorHandler(), 'handleException' ] );


### PR DESCRIPTION
- fix potential deprecation warnings
	- [x] 3 risky tests
	- [x] 1 phpstan deprecation warning