### PR TITLE
Add types for arrays

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,8 +1,5 @@
 parameters:
 	inferPrivatePropertyTypeFromConstructor: true
-	ignoreErrors:
-		-
-			identifier: missingType.iterableValue
 
 includes:
 	- vendor/phpstan/phpstan-phpunit/extension.neon

--- a/phpstan.prod.neon
+++ b/phpstan.prod.neon
@@ -1,5 +1,2 @@
 parameters:
 	inferPrivatePropertyTypeFromConstructor: true
-	ignoreErrors:
-		-
-			identifier: missingType.iterableValue

--- a/src/Entity/Visitor.php
+++ b/src/Entity/Visitor.php
@@ -11,6 +11,7 @@ class Visitor {
 
 	private int $totalImpressionCount = 0;
 	private ?string $bucketIdentifier;
+	/** @var string[] */
 	private array $activeCategories;
 	private int $displayWidth;
 
@@ -24,7 +25,8 @@ class Visitor {
 			int $totalImpressionCount,
 			?string $bucketIdentifier,
 			int $displayWidth,
-			string ...$activeCategories ) {
+			string ...$activeCategories
+	) {
 		$this->totalImpressionCount = $totalImpressionCount;
 		$this->bucketIdentifier = $bucketIdentifier;
 		$this->displayWidth = $displayWidth;

--- a/src/Utils/CampaignConfigurationLoader.php
+++ b/src/Utils/CampaignConfigurationLoader.php
@@ -31,6 +31,10 @@ class CampaignConfigurationLoader {
 		return new CampaignCollection( ...$campaigns );
 	}
 
+	/**
+	 * @param string $campaignName
+	 * @param array<string,mixed> $campaignData
+	 */
 	private function buildCampaignFromData( string $campaignName, array $campaignData ): Campaign {
 		$buckets = $this->buildBucketsFromData( $campaignData );
 		if ( empty( $buckets ) ) {
@@ -60,6 +64,10 @@ class CampaignConfigurationLoader {
 		);
 	}
 
+	/**
+	 * @param array<string,mixed> $campaignData
+	 * @return Bucket[]
+	 */
 	private function buildBucketsFromData( array $campaignData ): array {
 		$buckets = [];
 		foreach ( $campaignData['buckets'] as $bucketData ) {
@@ -69,6 +77,10 @@ class CampaignConfigurationLoader {
 		return $buckets;
 	}
 
+	/**
+	 * @param array<string,mixed> $bucketData
+	 * @return Bucket
+	 */
 	private function buildBucketFromData( array $bucketData ): Bucket {
 		if ( !isset( $bucketData['name'] ) ) {
 			throw new InvalidConfigurationValueException( 'A configured bucket has no name.' );
@@ -83,6 +95,10 @@ class CampaignConfigurationLoader {
 		return new Bucket( $bucketData['name'], array_shift( $banners ), ...$banners );
 	}
 
+	/**
+	 * @param string[] $bannerData
+	 * @return Banner[]
+	 */
 	private function buildBannersFromData( array $bannerData ): array {
 		$banners = [];
 		foreach ( $bannerData as $bannerIdentifier ) {
@@ -94,10 +110,16 @@ class CampaignConfigurationLoader {
 		return $banners;
 	}
 
+	/**
+	 * @return array<string,mixed>
+	 */
 	private function parseConfiguration(): array {
 		return Yaml::parseFile( $this->configFile );
 	}
 
+	/**
+	 * @param array<string,mixed> $campaignData
+	 */
 	private function integerOrNullValue( array $campaignData, string $key ): ?int {
 		if ( !isset( $campaignData[$key] ) ) {
 			return null;

--- a/tests/Unit/EventListener/ExceptionListenerTest.php
+++ b/tests/Unit/EventListener/ExceptionListenerTest.php
@@ -25,6 +25,11 @@ class ExceptionListenerTest extends KernelTestCase {
 		$this->dispatcher = new EventDispatcher();
 	}
 
+	/** solves tests marked as "risky" by phpunit, error was: "Test code or tested code did not remove its own exception handlers" */
+	public function tearDown(): void {
+		restore_exception_handler();
+	}
+
 	public function testGivenExceptionForJavaScriptUrl_thenEmptyInternalServerErrorMessageIsReturned(): void {
 		$this->withExceptionListener( new TestHandler() );
 


### PR DESCRIPTION
The `CampaignConfigurationLoader` is responsible for turning the untyped array that comes out of parsing a YAML file into a properly typed class. Therefore the array values need to be a bit "sloppy" (i.e. `mixed`). But it fixes the PHPStan errors, so we don't need an exception for them.