### PR TITLE
Set umask to make files group-writable

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,39 +1,44 @@
 <?php
 
-use WMDE\BannerServer\Kernel;
 use Symfony\Component\Dotenv\Dotenv;
 use Symfony\Component\ErrorHandler\Debug;
 use Symfony\Component\HttpFoundation\Request;
+use WMDE\BannerServer\Kernel;
 
-require __DIR__.'/../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 // The check is to ensure we don't use .env in production
-if (!isset($_SERVER['APP_ENV']) && !isset($_ENV['APP_ENV'])) {
-    if (!class_exists(Dotenv::class)) {
-        throw new \RuntimeException('APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.');
-    }
-    (new Dotenv())->load(__DIR__.'/../.env');
+if ( !isset( $_SERVER['APP_ENV'] ) && !isset( $_ENV['APP_ENV'] ) ) {
+	if ( !class_exists( Dotenv::class ) ) {
+		throw new \RuntimeException( 'APP_ENV environment variable is not defined. You need to define environment variables for configuration or add "symfony/dotenv" as a Composer dependency to load variables from a .env file.' );
+	}
+	( new Dotenv() )->load( __DIR__ . '/../.env' );
 }
 
 $env = $_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? 'dev';
-$debug = (bool) ($_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? ('prod' !== $env));
+$debug = (bool)( $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? ( 'prod' !== $env ) );
 
-if ($debug) {
-    umask(0000);
+// The default `umask` value on our banner server is `022`. This is restricting group write permissions.
+// 002 allows for all others in the same group to also create+modify files.
+// The web server and the deployment user are both in the same group, which allows the deployment user to
+// delete old deployments where the web server has written cache files
+umask( 0002 );
+if ( $debug ) {
+	umask( 0000 );
 
-    Debug::enable();
+	Debug::enable();
 }
 
-if ($trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false) {
-    Request::setTrustedProxies(explode(',', $trustedProxies), Request::HEADER_X_FORWARDED_FOR ^ Request::HEADER_X_FORWARDED_HOST);
+if ( $trustedProxies = $_SERVER['TRUSTED_PROXIES'] ?? $_ENV['TRUSTED_PROXIES'] ?? false ) {
+	Request::setTrustedProxies( explode( ',', $trustedProxies ), Request::HEADER_X_FORWARDED_FOR ^ Request::HEADER_X_FORWARDED_HOST );
 }
 
-if ($trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false) {
-    Request::setTrustedHosts(explode(',', $trustedHosts));
+if ( $trustedHosts = $_SERVER['TRUSTED_HOSTS'] ?? $_ENV['TRUSTED_HOSTS'] ?? false ) {
+	Request::setTrustedHosts( explode( ',', $trustedHosts ) );
 }
 
-$kernel = new Kernel($env, $debug);
+$kernel = new Kernel( $env, $debug );
 $request = Request::createFromGlobals();
-$response = $kernel->handle($request);
+$response = $kernel->handle( $request );
 $response->send();
-$kernel->terminate($request, $response);
+$kernel->terminate( $request, $response );


### PR DESCRIPTION
This ensures that when cleaning up old deploys, the `deploy` user can
delete old caches and temporary files, created by the `www-user`. Both
users are in the `www-data` group.

Ticket: https://phabricator.wikimedia.org/T376646
