### PR TITLE
Remove Scrutinizer coverage upload

### DIFF
--- a/.woodpecker/ci.yml
+++ b/.woodpecker/ci.yml
@@ -2,11 +2,7 @@ clone:
     git:
         image: woodpeckerci/plugin-git
         settings:
-            # "partial: false" and depth will copy several commits from the source repo,
-            # enabling history checks for the ocular tool
             # "lfs: false" disables downloading resources from LFS, which we don't use
-            partial: false
-            depth: 10
             lfs: false
 
 matrix:
@@ -35,6 +31,4 @@ steps:
           - vendor/bin/phpcs
           - php -d xdebug.mode=coverage vendor/bin/phpunit --coverage-clover coverage.xml
           - php -d memory_limit=1G vendor/bin/phpstan analyse --level=9 --no-progress src/ tests/
-          # Upload coverage to Scrutinizer
-          - ocular code-coverage:upload --no-interaction --format=php-clover coverage.xml
 


### PR DESCRIPTION
We're no longer using Scrutinizer and should not upload our coverage to
it.

This commit fixes the CI pipeline for other commits.
